### PR TITLE
[jest-plugin-it-renders] Lower the semver required for the react-test-renderer to ^16.0.0-alpha

### DIFF
--- a/packages/jest-plugin-it-renders/package.json
+++ b/packages/jest-plugin-it-renders/package.json
@@ -20,7 +20,7 @@
     "setup.js"
   ],
   "dependencies": {
-    "react-test-renderer": "^16.0.0-beta.5"
+    "react-test-renderer": "^16.0.0-alpha"
   },
   "peerDependencies": {
     "jest": "*",
@@ -28,7 +28,7 @@
     "react": "*"
   },
   "devDependencies": {
-    "react": "^16.0.0-beta.5"
+    "react": "^16.0.0-alpha"
   },
   "scripts": {
     "build": "babel src --out-dir build --ignore \"**/__tests__/**\"",

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,8 +836,8 @@ babel-preset-jest@^20.0.3:
     babel-plugin-jest-hoist "^20.0.3"
 
 babel-preset-jolt@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jolt/-/babel-preset-jolt-2.8.0.tgz#3fcaaa11f9e88a04bf90ccde1f66a01fa0a11d59"
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jolt/-/babel-preset-jolt-2.8.3.tgz#966c5ab2d59524ac37c558491e8e78f8ace59146"
   dependencies:
     babel-plugin-transform-builtin-extend "^1.1.2"
     babel-plugin-transform-class-properties "^6.24.1"
@@ -1582,8 +1582,8 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
 
 electron-to-chromium@^1.3.18:
-  version "1.3.19"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.19.tgz#73d97b0e8b05aa776cedf3cdce7fdc0538037675"
+  version "1.3.20"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.20.tgz#2eedd5ccbae7ddc557f68ad1fce9c172e915e4e5"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -1684,8 +1684,8 @@ escope@^3.6.0:
     estraverse "^4.1.1"
 
 eslint-config-jolt@^2.6.1:
-  version "2.7.8"
-  resolved "https://registry.yarnpkg.com/eslint-config-jolt/-/eslint-config-jolt-2.7.8.tgz#0a1d66c642867b2af9f19ad3a8facd03a2d4a617"
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/eslint-config-jolt/-/eslint-config-jolt-2.8.3.tgz#23e0ce97cfff718862e397efa934092a93965419"
   dependencies:
     babel-eslint "^7.0.0"
     eslint "^3.8.1"
@@ -4006,7 +4006,7 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-test-renderer@^16.0.0-beta.5:
+react-test-renderer@^16.0.0-alpha:
   version "16.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0-beta.5.tgz#6169e2ea96e8d21645662b369c23239974cd1f11"
   dependencies:
@@ -4020,7 +4020,7 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@^16.0.0-beta.5:
+react@^16.0.0-alpha:
   version "16.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0-beta.5.tgz#b4abba9bce7db72c30633db54a148614b6574e79"
   dependencies:
@@ -4128,11 +4128,10 @@ regenerator-transform@^0.10.0:
     private "^0.1.6"
 
 regex-cache@^0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
   dependencies:
     is-equal-shallow "^0.1.3"
-    is-primitive "^2.0.0"
 
 regexpu-core@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Issues Fixed

## Description

## Screenshot

## TODO
