### PR TITLE
[jest-plugin-fs] Replace mock-fs with memfs to not override the filesystem

### DIFF
--- a/packages/jest-plugin-fs/package.json
+++ b/packages/jest-plugin-fs/package.json
@@ -21,7 +21,7 @@
     "setup.js"
   ],
   "dependencies": {
-    "mock-fs": "^4.4.1"
+    "memfs": "^2.5.5"
   },
   "peerDependencies": {
     "jest": "*",

--- a/packages/jest-plugin-fs/setup.js
+++ b/packages/jest-plugin-fs/setup.js
@@ -3,3 +3,4 @@
  * test files.
  */
 global.fs = require('./').default;
+global.fs.inject();

--- a/packages/jest-plugin-fs/src/__tests__/fs.spec.js
+++ b/packages/jest-plugin-fs/src/__tests__/fs.spec.js
@@ -1,20 +1,25 @@
 // Modules
 import fsExtra from 'fs-extra';
 import set from 'jest-plugin-set';
+import context from 'jest-plugin-context';
 import fs from '../fs';
 
 
 /* eslint-disable no-undef */
 describe('fs', () => {
-  beforeEach(() => fs.mock());
-  afterEach(() => fs.restore());
+  beforeEach(() => fs.inject());
 
-  describe('new file', () => {
-    set('filename', () => 'some/path/to/file.txt');
-    beforeEach(() => fsExtra.outputFileSync(filename, 'test-content'));
+  context('with mock fs', () => {
+    beforeEach(() => fs.mock());
+    afterEach(() => fs.restore());
 
-    it('should create the new file', () => {
-      expect(fsExtra.readFileSync(filename, 'utf8')).toEqual('test-content');
+    context('with new file', () => {
+      set('filename', () => 'some/path/to/file.txt');
+      beforeEach(() => fsExtra.outputFileSync(filename, 'test-content'));
+
+      it('should create the new file', () => {
+        expect(fsExtra.readFileSync(filename, 'utf8')).toEqual('test-content');
+      });
     });
   });
 });

--- a/packages/jest-plugin-fs/src/__tests__/fs.spec.js
+++ b/packages/jest-plugin-fs/src/__tests__/fs.spec.js
@@ -1,4 +1,5 @@
 // Modules
+import '../../setup';
 import fsExtra from 'fs-extra';
 import set from 'jest-plugin-set';
 import context from 'jest-plugin-context';
@@ -7,19 +8,15 @@ import fs from '../fs';
 
 /* eslint-disable no-undef */
 describe('fs', () => {
-  beforeEach(() => fs.inject());
+  beforeEach(() => fs.mock());
+  afterEach(() => fs.restore());
 
-  context('with mock fs', () => {
-    beforeEach(() => fs.mock());
-    afterEach(() => fs.restore());
+  context('with new file', () => {
+    set('filename', () => 'some/path/to/file.txt');
+    beforeEach(() => fsExtra.outputFileSync(filename, 'test-content'));
 
-    context('with new file', () => {
-      set('filename', () => 'some/path/to/file.txt');
-      beforeEach(() => fsExtra.outputFileSync(filename, 'test-content'));
-
-      it('should create the new file', () => {
-        expect(fsExtra.readFileSync(filename, 'utf8')).toEqual('test-content');
-      });
+    it('should create the new file', () => {
+      expect(fsExtra.readFileSync(filename, 'utf8')).toEqual('test-content');
     });
   });
 });

--- a/packages/jest-plugin-fs/src/fs.js
+++ b/packages/jest-plugin-fs/src/fs.js
@@ -3,7 +3,7 @@ import memfs from 'memfs';
 
 
 const fs = {
-  inject: () => jest.mock('fs-extra', () => require('memfs').fs),
+  inject: () => jest.mock('fs', () => require('memfs').fs),
   mock: (filesystem = {}) => memfs.vol.fromJSON(filesystem, '/'),
   read: () => memfs.vol.toJSON(),
   restore: () => memfs.vol.reset(),

--- a/packages/jest-plugin-fs/src/fs.js
+++ b/packages/jest-plugin-fs/src/fs.js
@@ -3,13 +3,7 @@ import memfs from 'memfs';
 
 
 const fs = {
-  // For jest, this will set up mocks so that `fs` and `fs-extra` will
-  // be overwritten.
-  inject: () => {
-    jest.mock('fs', () => require('memfs'));
-    jest.mock('fs-extra', () => require('memfs'));
-  },
-
+  inject: () => jest.mock('fs-extra', () => require('memfs').fs),
   mock: (filesystem = {}) => memfs.vol.fromJSON(filesystem, '/'),
   read: () => memfs.vol.toJSON(),
   restore: () => memfs.vol.reset(),

--- a/packages/jest-plugin-fs/src/fs.js
+++ b/packages/jest-plugin-fs/src/fs.js
@@ -1,10 +1,18 @@
 // Libraries
-import mockFs from 'mock-fs';
+import memfs from 'memfs';
 
 
 const fs = {
-  mock: (filesystem = {}) => mockFs(filesystem),
-  restore: () => mockFs.restore(),
+  // For jest, this will set up mocks so that `fs` and `fs-extra` will
+  // be overwritten.
+  inject: () => {
+    jest.mock('fs', () => require('memfs'));
+    jest.mock('fs-extra', () => require('memfs'));
+  },
+
+  mock: (filesystem = {}) => memfs.vol.fromJSON(filesystem, '/'),
+  read: () => memfs.vol.toJSON(),
+  restore: () => memfs.vol.reset(),
 };
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,6 +2046,10 @@ fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
+fast-extend@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/fast-extend/-/fast-extend-0.0.2.tgz#f5ec42cf40b9460f521a6387dfb52deeed671dbd"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -2170,6 +2174,10 @@ fs-extra@^4.0.1:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
     universalify "^0.1.0"
+
+fs-monkey@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-0.2.1.tgz#aa1b88209edd1e0b08c83d638a4f5c67ed518550"
 
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
@@ -3722,6 +3730,13 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memfs@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-2.5.5.tgz#9320907de697476b81085052e71f12b608e94817"
+  dependencies:
+    fast-extend "0.0.2"
+    fs-monkey "^0.2.1"
+
 meow@^3.3.0, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -3806,10 +3821,6 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-mock-fs@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.4.1.tgz#f285fa025b42a4031faf75b66f632b21e7056683"
 
 mockdate@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
## Issues Fixed

Fix #63 

## Description

## Screenshot

## TODO
