### PR TITLE
Add comment about types

### DIFF
--- a/packages/jest-plugin-context/README.md
+++ b/packages/jest-plugin-context/README.md
@@ -68,3 +68,10 @@ describe('User', () => {
   });
 });
 ```
+
+## Types for Typescript
+
+Types are available for this package. Install them using yarn:
+```
+yarn add --dev @types/jest-plugin-context
+```


### PR DESCRIPTION
## Description

This adds a comment about available types for `jest-plugin-context`.